### PR TITLE
Publish doc CI

### DIFF
--- a/.github/push_doc.yml
+++ b/.github/push_doc.yml
@@ -1,0 +1,29 @@
+name: Publish documentation
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install .[doc]
+      - name: Sphinx build
+        run: sphinx-build doc _build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          force_orphan: true


### PR DESCRIPTION
Publish the doc by building the Sphinx script and pushing the result to the gh-page branch. Then, Github Page serves the gh-page directly.