### PR TITLE
Update the computing risk incidence loss to remove a bias

### DIFF
--- a/hazardous/_ipcw.py
+++ b/hazardous/_ipcw.py
@@ -4,7 +4,7 @@ from scipy.interpolate import interp1d
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_is_fitted
 
-from .utils import check_y_survival
+from .utils import check_event_of_interest, check_y_survival
 
 
 class IPCWEstimator(BaseEstimator):
@@ -30,7 +30,17 @@ class IPCWEstimator(BaseEstimator):
 
     Note: this estimator extrapolates with a constant value equal to the last
     IPCW value beyond the last observed time.
+
+    Parameters
+    ----------
+    event_of_interest : int or any
+        If integer, this estimator estimates the aggregate survival function to
+        either censoring or any other competing event.
+        If "any", this estimator estimates to censoring.
     """
+
+    def __init__(self, event_of_interest="any"):
+        self.event_of_interest = event_of_interest
 
     def fit(self, y):
         """Compute the censoring survival function using Kaplan Meier
@@ -49,7 +59,11 @@ class IPCWEstimator(BaseEstimator):
         event, duration = check_y_survival(y)
 
         km = KaplanMeierFitter()
-        censoring = event == 0
+        check_event_of_interest(self.event_of_interest)
+        if self.event_of_interest == "any":
+            censoring = event == 0
+        else:
+            censoring = event != self.event_of_interest
         km.fit(
             durations=duration,
             event_observed=censoring,

--- a/hazardous/metrics/_brier_score.py
+++ b/hazardous/metrics/_brier_score.py
@@ -189,8 +189,8 @@ class IncidenceScoreComputer:
         else:
             k = self.event_of_interest
 
-        # Specify the binary classification target for each record in y and
-        # a reference time horizon:
+        # Specify the binary classification target for each record in y and a
+        # reference time horizon:
         #
         # - 1 when event of interest was observed before the reference time
         #   horizon,
@@ -198,7 +198,8 @@ class IncidenceScoreComputer:
         # - 0 otherwise: any other event happening at any time, censored record
         #   or event of interest happening after the reference time horizon.
         #
-        #   Note: censored events only contribute (as negative target) when
+        #   Note: censored events and optionally competing events (other thant
+        #   the event of interest) only contribute (as negative target) when
         #   their duration is larger than the reference target horizon.
         #   Otherwise, they are discarded by setting their weight to 0 in the
         #   following.
@@ -206,6 +207,8 @@ class IncidenceScoreComputer:
         y_binary = np.zeros(y_event.shape[0], dtype=np.int32)
         y_binary[(y_event == k) & (y_duration <= times)] = 1
 
+        # TODO: update the following comments to match the code.
+        #
         # Compute the weights for each term contributing to the Brier score
         # at the specified time horizons.
         #
@@ -222,8 +225,7 @@ class IncidenceScoreComputer:
 
         # Estimate the probability of censoring at current time point t.
         ipcw_times = self.ipcw_est.compute_ipcw_at(times)
-        before = times < y_duration
-        weights = np.where(before, ipcw_times, 0)
+        weights = np.where(y_duration > times, ipcw_times, 0)
         weights = np.where(y_binary, ipcw_y_duration, weights)
 
         return y_binary, weights

--- a/hazardous/metrics/_brier_score.py
+++ b/hazardous/metrics/_brier_score.py
@@ -44,12 +44,7 @@ class IncidenceScoreComputer:
 
         # Estimate the censoring distribution from the training set
         # using Kaplan-Meier.
-        self.ipcw_est = IPCWEstimator().fit(
-            dict(
-                event=self.any_event_train,
-                duration=self.duration_train,
-            )
-        )
+        self.ipcw_est = IPCWEstimator(event_of_interest=event_of_interest).fit(y_train)
 
         # Precompute the censoring probabilities at the time of the events on the
         # training set:
@@ -101,6 +96,7 @@ class IncidenceScoreComputer:
     def brier_score_incidence(self, y_true, y_pred, times):
         """Brier score for the cause-specific cumulative incidence function.
 
+        TODO: UPDATE
         Compute the Brier score values with IPCW adjustment for censoring for
         each cumulative incidence estimate for the event of interest and each
         requested time point and return the time-dependent Brier score averaged
@@ -355,6 +351,7 @@ def brier_score_incidence(
 ):
     r"""Time-dependent Brier score for the kth cause of event.
 
+    TODO: UPDATE
     .. math::
 
         \mathrm{BS}_k(t) = \frac{1}{n} \sum_{i=1}^n \hat{\omega}_i(t)

--- a/hazardous/metrics/_brier_score.py
+++ b/hazardous/metrics/_brier_score.py
@@ -224,9 +224,7 @@ class IncidenceScoreComputer:
         ipcw_times = self.ipcw_est.compute_ipcw_at(times)
         before = times < y_duration
         weights = np.where(before, ipcw_times, 0)
-
-        after_any_observed_event = (y_event > 0) & (y_duration <= times)
-        weights = np.where(after_any_observed_event, ipcw_y_duration, weights)
+        weights = np.where(y_binary, ipcw_y_duration, weights)
 
         return y_binary, weights
 


### PR DESCRIPTION
In the example there is still a bias, so there might be a bug, we need to investigate.

EDIT (Olivier): the bias goes away when increasing the number of trees (`n_iter`) with `n_samples`.

This PR is actually an estimator for the cause-specific cumulative density functions for each event type. It estimates the cumulative incidence if it were possible to remove the competing event types which is rarely the case in practice (e.g. remove all other causes of death to study cancer incidence). I don't think this is what we want to estimate in practice. See https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5557056/ for instance.