### PR TITLE
Improve Brier score testing

### DIFF
--- a/hazardous/_gradient_boosting_incidence.py
+++ b/hazardous/_gradient_boosting_incidence.py
@@ -128,12 +128,12 @@ class GradientBoostingIncidence(BaseEstimator, ClassifierMixin):
 
     time_horizon : float or int, default=None
         A specific time horizon `t_horizon` to treat the model as a
-        probabilistic classifier to estimate `E[T_k < t_horizon|X]` where `T_k`
-        is a random variable representing the (uncensored) event for the type
-        of interest.
+        probabilistic classifier to estimate `E[T < t_horizon, E = k|X]` where
+        `T` is a random variable representing the (uncensored) event and E a
+        random categorical variable representing the (uncensored) event type.
 
         When specified, the `predict_proba` method returns an estimate of
-        `E[T_k < t_horizon|X]` for each provided realisation of `X`.
+        `E[T < t_horizon, E = k|X]` for each provided realisation of `X`.
 
     monotonic_incidence : str or False, default=False
         Whether to constrain the CIF to be monotonic with respect to time.

--- a/hazardous/_gradient_boosting_incidence.py
+++ b/hazardous/_gradient_boosting_incidence.py
@@ -89,7 +89,7 @@ class GradientBoostingIncidence(BaseEstimator, ClassifierMixin):
 
     Estimate a cause-specific CIF by iteratively minimizing a stochastic time
     integrated proper scoring rule (Brier score or binary cross-entropy) for
-    the kth cause of failure from _[1].
+    the kth cause of failure from [Kretowska2018]_.
 
     Under the hood, this class uses randomly sampled reference time horizons
     concatenated as an extra input column to the underlying HGB binary
@@ -156,9 +156,20 @@ class GradientBoostingIncidence(BaseEstimator, ClassifierMixin):
     References
     ----------
 
-    .. [1] M. Kretowska, Tree-based models for survival data with competing
-           risks, Computer Methods and Programs in Biomedicine 159 (2018)
-           185-198.
+    .. [Graf1999] E. Graf, C. Schmoor, W. Sauerbrei, M. Schumacher, "Assessment
+       and comparison of prognostic classification schemes for survival data",
+       1999
+
+    .. [Kretowska2018] M. Kretowska, "Tree-based models for survival data with
+       competing risks", 2018
+
+    .. [Gerds2006] T. Gerds and M. Schumacher, "Consistent Estimation of the
+       Expected Brier Score in General Survival Models with Right-Censored
+       Event Times", 2006
+
+    .. [Edwards2016] J. Edwards, L. Hester, M. Gokhale, C. Lesko,
+       "Methodologic Issues When Estimating Risks in Pharmacoepidemiology.",
+       2016, doi:10.1007/s40471-016-0089-1
     """
 
     def __init__(

--- a/hazardous/_gradient_boosting_incidence.py
+++ b/hazardous/_gradient_boosting_incidence.py
@@ -129,8 +129,8 @@ class GradientBoostingIncidence(BaseEstimator, ClassifierMixin):
     time_horizon : float or int, default=None
         A specific time horizon `t_horizon` to treat the model as a
         probabilistic classifier to estimate `E[T < t_horizon, E = k|X]` where
-        `T` is a random variable representing the (uncensored) event and E a
-        random categorical variable representing the (uncensored) event type.
+        `T` is a random variable representing the (uncensored) event and `E`
+        a random categorical variable representing the (uncensored) event type.
 
         When specified, the `predict_proba` method returns an estimate of
         `E[T < t_horizon, E = k|X]` for each provided realisation of `X`.

--- a/hazardous/_gradient_boosting_incidence.py
+++ b/hazardous/_gradient_boosting_incidence.py
@@ -128,12 +128,12 @@ class GradientBoostingIncidence(BaseEstimator, ClassifierMixin):
 
     time_horizon : float or int, default=None
         A specific time horizon `t_horizon` to treat the model as a
-        probabilistic classifier to estimate `E[T < t_horizon, E = k|X]` where
-        `T` is a random variable representing the (uncensored) event and `E`
+        probabilistic classifier to estimate ``𝔼[T < t_horizon, E = k|X]`` where
+        ``T`` is a random variable representing the (uncensored) event and ``E``
         a random categorical variable representing the (uncensored) event type.
 
-        When specified, the `predict_proba` method returns an estimate of
-        `E[T < t_horizon, E = k|X]` for each provided realisation of `X`.
+        When specified, the ``predict_proba`` method returns an estimate of
+        ``𝔼[T < t_horizon, E = k|X]`` for each provided realization of ``X``.
 
     monotonic_incidence : str or False, default=False
         Whether to constrain the CIF to be monotonic with respect to time.

--- a/hazardous/_gradient_boosting_incidence.py
+++ b/hazardous/_gradient_boosting_incidence.py
@@ -89,7 +89,7 @@ class GradientBoostingIncidence(BaseEstimator, ClassifierMixin):
 
     Estimate a cause-specific CIF by iteratively minimizing a stochastic time
     integrated proper scoring rule (Brier score or binary cross-entropy) for
-    the kth cause of failure from [Kretowska2018]_.
+    the kth cause of failure as defined in equation 14 in [Kretowska2018]_.
 
     Under the hood, this class uses randomly sampled reference time horizons
     concatenated as an extra input column to the underlying HGB binary

--- a/hazardous/metrics/_brier_score.py
+++ b/hazardous/metrics/_brier_score.py
@@ -389,20 +389,24 @@ def brier_score_incidence(
         \mathrm{BS}_k(t) = \frac{1}{n} \sum_{i=1}^n \hat{\omega}_i(t)
         (\mathbb{I}(t_i \leq t, \delta_i = k) - \hat{F}_k(t|\mathbf{x}_i))^2
 
-    where :math:`\hat{F}_k(t | \mathbf{x}_i)` is the estimate of the cumulative
-    incidence for the kth event up to time point :math:`t` for a feature vector
-    :math:`\mathbf{x}_i`, and
+    where :math:`\hat{F}_k(t | \mathbf{x}_i)` is the estimate of the
+    (uncensored) cumulative incidence for the kth event up to time point
+    :math:`t` for a feature vector :math:`\mathbf{x}_i` [4]:
 
     .. math::
 
-        \hat{\omega}_i(t)=\mathbb{I}(t_i \leq t, \delta_i \neq 0)/\hat{G}(t_i)
-        + \mathbb{I}(t_i > t)/\hat{G}(t)
+            \hat{F}_k(t | \mathbf{x}_i) = P(T_i \leq t, E_i = k | \mathbf{x}_i)
 
-    are IPCW weigths based on the Kaplan-Meier estimate of the censoring
-    distribution :math:`\hat{G}(t)`.
+    and :math:`\hat{\omega}_i(t)` are IPCW weigths based on the Kaplan-Meier
+    estimate of the censoring distribution :math:`\hat{G}(t)`:
 
-    This scheme was introduced in [1] for survival analysis and extended to
-    competing events in [2].
+    .. math::
+
+        \hat{\omega}_i(t)=\frac{\mathbb{I}(t_i \leq t, \delta_i \neq 0)}{\hat{G}(t_i)}
+        + \frac{\mathbb{I}(t_i > t)}{\hat{G}(t)}
+
+    This scheme was introduced in [1] in the context of survival analysis and
+    extended to competing events in [2].
 
     Note that this assumes independence between censoring and the covariates.
     When this assumption is violated, the IPCW weights are biased and the Brier
@@ -451,11 +455,16 @@ def brier_score_incidence(
     [1] Assessment and comparison of prognostic classification schemes for
         survival data, E. Graf, C. Schmoor, W. Sauerbrei, M. Schumacher (1999)
 
-    [2] Tree-based models for survival data with competing risks, M. Kretowska (2018)
+    [2] Tree-based models for survival data with competing risks, M. Kretowska
+        (2018)
 
     [3] Consistent Estimation of the Expected Brier Score in General Survival
         Models with Right-Censored Event Times, T. Gerds and M. Schumacher
         (2006)
+
+    [4] Methodologic Issues When Estimating Risks in Pharmacoepidemiology.
+        J. Edwards, L. Hester, M. Gokhale, C. Lesko (2016)
+        doi: 10.1007/s40471-016-0089-1
     """
     # XXX: make times an optional kwarg to be compatible with
     # sksurv.metrics.brier_score?

--- a/hazardous/metrics/_brier_score.py
+++ b/hazardous/metrics/_brier_score.py
@@ -389,13 +389,13 @@ def brier_score_incidence(
         \mathrm{BS}_k(t) = \frac{1}{n} \sum_{i=1}^n \hat{\omega}_i(t)
         (\mathbb{I}(t_i \leq t, \delta_i = k) - \hat{F}_k(t|\mathbf{x}_i))^2
 
-    where :math:`\hat{F}_k(t | \mathbf{x}_i)` is the estimate of the
+    where :math:`\hat{F}_k(t | \mathbf{x}_i)` is an estimate of the
     (uncensored) cumulative incidence for the kth event up to time point
     :math:`t` for a feature vector :math:`\mathbf{x}_i` [4]:
 
     .. math::
 
-            \hat{F}_k(t | \mathbf{x}_i) = P(T_i \leq t, E_i = k | \mathbf{x}_i)
+            \hat{F}_k(t | \mathbf{x}_i) \approx P(T_i \leq t, E_i = k | \mathbf{x}_i)
 
     and :math:`\hat{\omega}_i(t)` are IPCW weigths based on the Kaplan-Meier
     estimate of the censoring distribution :math:`\hat{G}(t)`:

--- a/hazardous/metrics/_brier_score.py
+++ b/hazardous/metrics/_brier_score.py
@@ -206,9 +206,7 @@ class IncidenceScoreComputer:
         #   their duration is larger than the reference target horizon.
         #   Otherwise, they are discarded by setting their weight to 0 in the
         #   following.
-
-        y_binary = np.zeros(y_event.shape[0], dtype=np.int32)
-        y_binary[(y_event == k) & (y_duration <= times)] = 1
+        y_binary = ((y_event == k) & (y_duration <= times)).astype(np.int32)
 
         # Compute the weights for each term contributing to the Brier score
         # at the specified time horizons.

--- a/hazardous/metrics/_brier_score.py
+++ b/hazardous/metrics/_brier_score.py
@@ -411,7 +411,7 @@ def brier_score_incidence(
 
     Note that this assumes independence between censoring and the covariates.
     When this assumption is violated, the IPCW weights are biased and the Brier
-    score is not a proper scoring rule anymore. See [Gerds2006]` for a study of
+    score is not a proper scoring rule anymore. See [Gerds2006]_ for a study of
     this bias.
 
     Parameters
@@ -464,9 +464,9 @@ def brier_score_incidence(
        Expected Brier Score in General Survival Models with Right-Censored
        Event Times", 2006
 
-    .. [Edwards2016] :doi:`J. Edwards, L. Hester, M. Gokhale, C. Lesko,
+    .. [Edwards2016] J. Edwards, L. Hester, M. Gokhale, C. Lesko,
        "Methodologic Issues When Estimating Risks in Pharmacoepidemiology.",
-       2016 <10.1007/s40471-016-0089-1>`
+       2016, doi:10.1007/s40471-016-0089-1
     """
     # XXX: make times an optional kwarg to be compatible with
     # sksurv.metrics.brier_score?

--- a/hazardous/metrics/_brier_score.py
+++ b/hazardous/metrics/_brier_score.py
@@ -223,8 +223,10 @@ class IncidenceScoreComputer:
         #   they happen either before or after the reference time horizon.
         #
         # This IPCW scheme for survival analysis (binary events) is described
-        # in [1] and is extended to multiple competing events in [2].
-        y_binary = ((y_event == k) & (y_duration <= times)).astype(np.int32)
+        # in [Graf1999] and is extended to multiple competing events in
+        # [Kretowska2018].
+        event_k_before_horizon = (y_event == k) & (y_duration <= times)
+        y_binary = event_k_before_horizon.astype(np.int32)
 
         ipcw_times = self.ipcw_est.compute_ipcw_at(times)
         any_event_or_censoring_after_horizon = y_duration > times
@@ -260,7 +262,7 @@ def brier_score_survival(
 
     Note that this assumes independence between censoring and the covariates.
     When this assumption is violated, the IPCW weights are biased and the Brier
-    score is not a proper scoring rule anymore. See [3] for a study of this
+    score is not a proper scoring rule anymore. See [Gerds2006]_ for a study of this
     bias.
 
     Parameters
@@ -296,12 +298,13 @@ def brier_score_survival(
 
     References
     ----------
-    [1] Assessment and comparison of prognostic classification schemes for
-        survival data, E. Graf, C. Schmoor, W. Sauerbrei, M. Schumacher (1999)
+    .. [Graf1999] E. Graf, C. Schmoor, W. Sauerbrei, M. Schumacher, "Assessment
+       and comparison of prognostic classification schemes for survival data",
+       1999
 
-    [3] Consistent Estimation of the Expected Brier Score in General Survival
-        Models with Right-Censored Event Times, T. Gerds and M. Schumacher
-        (2006)
+    .. [Gerds2006] T. Gerds and M. Schumacher, "Consistent Estimation of the
+       Expected Brier Score in General Survival Models with Right-Censored
+       Event Times", 2006
     """
     computer = IncidenceScoreComputer(
         y_train,
@@ -325,8 +328,8 @@ def integrated_brier_score_survival(
 
     Note that this assumes independence between censoring and the covariates.
     When this assumption is violated, the IPCW weights are biased and the Brier
-    score is not a proper scoring rule anymore. See [3] for a study of this
-    bias.
+    score is not a proper scoring rule anymore. See [Gerds2006]_ for a study of
+    this bias.
 
     Parameters
     ----------
@@ -361,12 +364,13 @@ def integrated_brier_score_survival(
 
     References
     ----------
-    [1] Assessment and comparison of prognostic classification schemes for
-        survival data, E. Graf, C. Schmoor, W. Sauerbrei, M. Schumacher (1999)
+    .. [Graf1999] E. Graf, C. Schmoor, W. Sauerbrei, M. Schumacher, "Assessment
+       and comparison of prognostic classification schemes for survival data",
+       1999
 
-    [3] Consistent Estimation of the Expected Brier Score in General Survival
-        Models with Right-Censored Event Times, T. Gerds and M. Schumacher
-        (2006)
+    .. [Gerds2006] T. Gerds and M. Schumacher, "Consistent Estimation of the
+       Expected Brier Score in General Survival Models with Right-Censored
+       Event Times", 2006
     """
     computer = IncidenceScoreComputer(
         y_train,
@@ -495,13 +499,13 @@ def integrated_brier_score_incidence(
         \mathrm{IBS}_k = \frac{1}{t_{max} - t_{min}} \int^{t_{max}}_{t_{min}}
         \mathrm{BS}_k(u) du
 
-    This scheme was introduced in [1] for survival analysis and extended to
-    competing events in [2].
+    This scheme was introduced in [Graf1999]_ for survival analysis and
+    extended to competing events in [Kretowska2018]_.
 
     Note that this assumes independence between censoring and the covariates.
     When this assumption is violated, the IPCW weights are biased and the Brier
-    score is not a proper scoring rule anymore. See [3] for a study of this
-    bias.
+    score is not a proper scoring rule anymore. See [Gerds2006]_ for a study of
+    this bias.
 
     Parameters
     ----------
@@ -541,15 +545,16 @@ def integrated_brier_score_incidence(
 
     References
     ----------
+    .. [Graf1999] E. Graf, C. Schmoor, W. Sauerbrei, M. Schumacher, "Assessment
+       and comparison of prognostic classification schemes for survival data",
+       1999
 
-    [1] Assessment and comparison of prognostic classification schemes for
-        survival data, E. Graf, C. Schmoor, W. Sauerbrei, M. Schumacher (1999)
+    .. [Kretowska2018] M. Kretowska, "Tree-based models for survival data with
+       competing risks", 2018
 
-    [2] Tree-based models for survival data with competing risks, M. Kretowska (2018)
-
-    [3] Consistent Estimation of the Expected Brier Score in General Survival
-        Models with Right-Censored Event Times, T. Gerds and M. Schumacher
-        (2006)
+    .. [Gerds2006] T. Gerds and M. Schumacher, "Consistent Estimation of the
+       Expected Brier Score in General Survival Models with Right-Censored
+       Event Times", 2006
     """
     computer = IncidenceScoreComputer(
         y_train,

--- a/hazardous/metrics/_brier_score.py
+++ b/hazardous/metrics/_brier_score.py
@@ -391,27 +391,28 @@ def brier_score_incidence(
 
     where :math:`\hat{F}_k(t | \mathbf{x}_i)` is an estimate of the
     (uncensored) cumulative incidence for the kth event up to time point
-    :math:`t` for a feature vector :math:`\mathbf{x}_i` [4]:
+    :math:`t` for a feature vector :math:`\mathbf{x}_i` [Edwards2016]_:
 
     .. math::
 
-            \hat{F}_k(t | \mathbf{x}_i) \approx P(T_i \leq t, E_i = k | \mathbf{x}_i)
+            \hat{F}_k(t | \mathbf{x}_i) \approx P(T_i \leq t, E_i = k |
+            \mathbf{x}_i)
 
     and :math:`\hat{\omega}_i(t)` are IPCW weigths based on the Kaplan-Meier
     estimate of the censoring distribution :math:`\hat{G}(t)`:
 
     .. math::
 
-        \hat{\omega}_i(t)=\frac{\mathbb{I}(t_i \leq t, \delta_i \neq 0)}{\hat{G}(t_i)}
-        + \frac{\mathbb{I}(t_i > t)}{\hat{G}(t)}
+        \hat{\omega}_i(t)=\frac{\mathbb{I}(t_i \leq t, \delta_i \neq
+        0)}{\hat{G}(t_i)} + \frac{\mathbb{I}(t_i > t)}{\hat{G}(t)}
 
-    This scheme was introduced in [1] in the context of survival analysis and
-    extended to competing events in [2].
+    This scheme was introduced in [Graf1999]_ in the context of survival
+    analysis and extended to competing events in [Kretowska2018]_.
 
     Note that this assumes independence between censoring and the covariates.
     When this assumption is violated, the IPCW weights are biased and the Brier
-    score is not a proper scoring rule anymore. See [3] for a study of this
-    bias.
+    score is not a proper scoring rule anymore. See [Gerds2006]` for a study of
+    this bias.
 
     Parameters
     ----------
@@ -452,19 +453,20 @@ def brier_score_incidence(
 
     References
     ----------
-    [1] Assessment and comparison of prognostic classification schemes for
-        survival data, E. Graf, C. Schmoor, W. Sauerbrei, M. Schumacher (1999)
+    .. [Graf1999] E. Graf, C. Schmoor, W. Sauerbrei, M. Schumacher, "Assessment
+       and comparison of prognostic classification schemes for survival data",
+       1999
 
-    [2] Tree-based models for survival data with competing risks, M. Kretowska
-        (2018)
+    .. [Kretowska2018] M. Kretowska, "Tree-based models for survival data with
+       competing risks", 2018
 
-    [3] Consistent Estimation of the Expected Brier Score in General Survival
-        Models with Right-Censored Event Times, T. Gerds and M. Schumacher
-        (2006)
+    .. [Gerds2006] T. Gerds and M. Schumacher, "Consistent Estimation of the
+       Expected Brier Score in General Survival Models with Right-Censored
+       Event Times", 2006
 
-    [4] Methodologic Issues When Estimating Risks in Pharmacoepidemiology.
-        J. Edwards, L. Hester, M. Gokhale, C. Lesko (2016)
-        doi: 10.1007/s40471-016-0089-1
+    .. [Edwards2016] :doi:`J. Edwards, L. Hester, M. Gokhale, C. Lesko,
+       "Methodologic Issues When Estimating Risks in Pharmacoepidemiology.",
+       2016 <10.1007/s40471-016-0089-1>`
     """
     # XXX: make times an optional kwarg to be compatible with
     # sksurv.metrics.brier_score?

--- a/hazardous/metrics/_brier_score.py
+++ b/hazardous/metrics/_brier_score.py
@@ -136,6 +136,16 @@ class IncidenceScoreComputer:
             else:
                 event_true = event_true > 0
 
+        if y_pred.ndim != 2:
+            raise ValueError(
+                "'y_pred' must be a 2D array with shape (n_samples, n_times), got"
+                f" shape {y_pred.shape}."
+            )
+        if y_pred.shape[0] != event_true.shape[0]:
+            raise ValueError(
+                "'y_true' and 'y_pred' must have the same number of samples, "
+                f"got {event_true.shape[0]} and {y_pred.shape[0]} respectively."
+            )
         if y_pred.shape[1] != times.shape[0]:
             raise ValueError(
                 f"'times' length ({times.shape[0]}) "

--- a/hazardous/tests/test_metrics.py
+++ b/hazardous/tests/test_metrics.py
@@ -302,13 +302,15 @@ def _sample_marginal_competing_weibull_data(
 def _integrate_weibull_incidence_curves(distribution_params, t_max):
     """Numerically integrate the Weibull hazard functions to get the CIFs.
 
-    The numerical integration is performed using a fine time grid and the
+    The numerical integration is performed using a very fine time grid and
+    then down-sampled to a coarser time grid to build the returned time
+    interpolators.
 
-    Note: in a competing risks setting, the cause-specific hazard functions are
+    Note: in a competing risks setting, the cause-specific incidence functions are
     coupled: they do not only depend on the distribution parameters that
     determine the cause-specific hazards but also on the aggregate survival to
     all competing events. This is why we need to integrate the hazard functions
-    to get the CIFs instead of just considering the parametric defintion of the
+    to get the CIFs instead of just considering the parametric definition of the
     cumulative density functions (CDFs) of the Weibull distribution.
     """
     fine_time_grid = np.linspace(0, 1.1 * t_max, num=1_000_000)

--- a/hazardous/tests/test_metrics.py
+++ b/hazardous/tests/test_metrics.py
@@ -1,10 +1,14 @@
 import re
+from functools import lru_cache
 
 import numpy as np
+import pandas as pd
 import pytest
 from lifelines import CoxPHFitter
 from lifelines.datasets import load_regression_dataset
 from numpy.testing import assert_allclose
+from scipy.interpolate import interp1d
+from scipy.stats import weibull_min
 
 from ..metrics import (
     brier_score_incidence,
@@ -236,3 +240,184 @@ def test_brier_score_survival_wrong_inputs():
             y_pred_survival,
             times[:5],
         )
+
+
+def _weibull_hazard(t, shape=1.0, scale=1.0):
+    """Weibull hazard function.
+
+    See: https://en.wikipedia.org/wiki/Weibull_distribution
+
+    This implementation plugs an arbitrary null hazard value at `t==0` because
+    fractional powers of 0 are undefined.
+
+    This does not seem to be mathematically correct but in practice it does
+    make it possible to integrate the hazard function into cumulative incidence
+    functions in a way that matches the Aalen-Johansen estimator.
+
+    See examples/plot_marginal_cumulative_incidence_estimation.py for a
+    visual confirmation.
+    """
+    with np.errstate(divide="ignore"):
+        weibull_hazard_at_t = (shape / scale) * (t / scale) ** (shape - 1.0)
+    return np.where(t == 0, 0.0, weibull_hazard_at_t)
+
+
+def _sample_marginal_competing_weibull_data(
+    distribution_params,
+    n_samples,
+    random_state=None,
+):
+    event_times = np.concatenate(
+        [
+            weibull_min.rvs(
+                dist["params"]["shape"],
+                scale=dist["params"]["scale"],
+                size=n_samples,
+                random_state=random_state,
+            ).reshape(-1, 1)
+            for dist in distribution_params
+        ],
+        axis=1,
+    )
+    event_ids = np.asarray([d["event_id"] for d in distribution_params])
+    first_event_idx = np.argmin(event_times, axis=1)
+
+    y = pd.DataFrame(
+        dict(
+            event=event_ids[first_event_idx],
+            duration=event_times[np.arange(n_samples), first_event_idx],
+        )
+    )
+    return y
+
+
+def _integrate_weibull_incidence_curves(distributions, t_max):
+    """Numerically integrate the Weibull hazard functions to get the CIFs.
+
+    The numerical integration is performed using a fine time grid and the
+
+    Note: in a competing risks setting, the cause-specific hazard functions are
+    coupled: they do not only depend on the distribution parameters that
+    determine the cause-specific hazards but also on the aggregate survival to
+    all competing events. This is why we need to integrate the hazard functions
+    to get the CIFs instead of just considering the parametric defintion of the
+    cumulative density functions (CDFs) of the Weibull distribution.
+    """
+    fine_time_grid = np.linspace(0, t_max, num=10_000_000)
+    dt = np.diff(fine_time_grid)[0]
+    all_hazards = np.stack(
+        [
+            _weibull_hazard(fine_time_grid, **dist["params"])
+            for dist in distributions
+            if dist["event_id"] > 0  # skip censoring distribution
+        ],
+        axis=0,
+    )
+    any_event_hazards = all_hazards.sum(axis=0)
+    any_event_survival = np.exp(-(any_event_hazards.cumsum(axis=-1) * dt))
+    cifs = [
+        ((hazards_i * any_event_survival).cumsum(axis=-1) * dt)
+        for hazards_i in all_hazards
+    ]
+    downscale_factor = fine_time_grid.size // 1000
+    return (
+        interp1d(
+            fine_time_grid[::downscale_factor],
+            any_event_survival[::downscale_factor],
+            kind="previous",
+            bounds_error=False,
+            fill_value="extrapolate",
+        ),
+        [
+            interp1d(
+                fine_time_grid[::downscale_factor],
+                cif[::downscale_factor],
+                kind="previous",
+                bounds_error=False,
+                fill_value="extrapolate",
+            )
+            for cif in cifs
+        ],
+    )
+
+
+@lru_cache()
+def _sample_test_data(
+    n_samples=10_000, base_scale=1000.0, censored=True, random_state=None
+):
+    distribution_params = [
+        {"event_id": 0, "params": {"scale": 3 * base_scale, "shape": 1}},  # censoring
+        {"event_id": 1, "params": {"scale": 10 * base_scale, "shape": 0.5}},
+        {"event_id": 2, "params": {"scale": 3 * base_scale, "shape": 1}},
+        {"event_id": 3, "params": {"scale": 3 * base_scale, "shape": 5}},
+    ]
+
+    if not censored:
+        distribution_params = distribution_params[1:]
+
+    data = _sample_marginal_competing_weibull_data(
+        distribution_params, n_samples=n_samples, random_state=random_state
+    )
+    t_max = data.query("event > 0")["duration"].max()
+    true_survival, true_cifs = _integrate_weibull_incidence_curves(
+        distribution_params, t_max
+    )
+
+    return data, true_survival, true_cifs, t_max
+
+
+@pytest.mark.parametrize("censored", [True, False])
+@pytest.mark.parametrize("relative_time_horizon", [0.2, 0.5, 0.8])
+@pytest.mark.parametrize("seed", range(2))
+def test_brier_score_optimality_survival(censored, relative_time_horizon, seed):
+    n_samples = 100_000
+    y, true_survival, _, t_max = _sample_test_data(
+        n_samples=n_samples, censored=censored, random_state=seed
+    )
+    if censored:
+        assert y["event"].min() == 0
+    else:
+        assert y["event"].min() > 0
+
+    # Convert competing event analysis data to data suitable for "any event"
+    # survival analysis by ignoring the event_id types.
+    y["event"] = (y["event"] > 0).astype(np.int32)
+
+    time_horizon = t_max * relative_time_horizon
+    expected_optimal_estimate = true_survival(time_horizon)
+    expected_best_bs = brier_score_survival(
+        y,
+        y,
+        np.full(shape=(n_samples, 1), fill_value=expected_optimal_estimate),
+        times=np.asarray([time_horizon]),
+    )[0]
+    survival_prob_grid = np.linspace(0, 1, num=11)
+    bs_values = np.asarray(
+        [
+            brier_score_survival(
+                y,
+                y,
+                np.full(shape=(n_samples, 1), fill_value=y_pred),
+                times=np.asarray([time_horizon]),
+            )
+            for y_pred in survival_prob_grid
+        ]
+    ).ravel()
+    assert bs_values.min() >= expected_best_bs
+
+    # Check that the Brier score makes it possible to discriminate between
+    # different survival probabilities estimate.
+    best_prob_estimate = survival_prob_grid[bs_values.argmin()]
+    assert best_prob_estimate == pytest.approx(expected_optimal_estimate, abs=0.1)
+
+
+@pytest.mark.parametrize("event_of_interest", [1, 2, 3])
+@pytest.mark.parametrize("censored", [True, False])
+@pytest.mark.parametrize("relative_time_horizon", [0.1, 0.5, 0.9])
+@pytest.mark.parametrize("seed", range(2))
+def test_brier_score_optimality_competing_risks(
+    event_of_interest, censored, relative_time_horizon, seed
+):
+    # TODO: adapt test_brier_score_optimality_survival to the competing risks
+    # setting.
+    pass


### PR DESCRIPTION
This a PR to check that our IPCW Brier score implementation behaves empirically as a proper scoring rule on a marginal model (no covariates).

This is similar to what we have in our example but only do marginal model estimation via the `brier_score_*` function on a grid of estimates.

This way we do not depend on any bias induced by underfitting caused by a bad tuning of the hyperparameters of a conditional model such as `GradientBoostingIncidence`.