### PR TITLE
FIX accept both float and array-like for time_horizon in predict_proba

### DIFF
--- a/hazardous/_survival_boost.py
+++ b/hazardous/_survival_boost.py
@@ -1,3 +1,5 @@
+from numbers import Real
+
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.ensemble import HistGradientBoostingClassifier
@@ -301,7 +303,9 @@ class SurvivalBoost(BaseEstimator, ClassifierMixin):
             else:
                 time_horizon = self.time_horizon
 
-        times = np.asarray([time_horizon])
+        if isinstance(time_horizon, Real):
+            time_horizon = [time_horizon]
+        times = np.asarray(time_horizon)
         return self.predict_cumulative_incidence(X, times=times)
 
     def predict_cumulative_incidence(self, X, times=None):

--- a/hazardous/_survival_boost.py
+++ b/hazardous/_survival_boost.py
@@ -286,7 +286,8 @@ class SurvivalBoost(BaseEstimator, ClassifierMixin):
             The input samples.
         time_horizon : float or array-like, default=None
             The time horizon at which to estimate the probabilities. If `None`, the
-            `time_horizon` passed at the constructor is used.
+            `time_horizon` passed at the constructor is used. Therefore, this
+            parameter allows to override the `time_horizon` set at the constructor.
 
         Returns
         -------

--- a/hazardous/_survival_boost.py
+++ b/hazardous/_survival_boost.py
@@ -284,18 +284,21 @@ class SurvivalBoost(BaseEstimator, ClassifierMixin):
         ----------
         X : array-like of shape (n_samples, n_features)
             The input samples.
+
         time_horizon : int or float, default=None
             The time horizon at which to estimate the probabilities. If `None`, the
             `time_horizon` passed at the constructor is used. Therefore, this
-            parameter allows to override the `time_horizon` set at the constructor.
+            parameter allows to override the `time_horizon` parameter passed to
+            the constructor.
 
         Returns
         -------
-        y_proba : ndarray of shape (n_events + 1, n_samples)
-            The estimated probabilities at the given time horizon. The first entry
-            at index 0 represents the survival probability (none of the events
-            occurring), whereas the remaining entries correspond to the incidence
-            probabilities for each specific event.
+        y_proba : ndarray of shape (n_samples, n_events + 1)
+            The estimated probabilities at the given time horizon. The column
+            indexed 0 stores the estimated probabilities of staying event-free at the
+            requested time horizon for each observation described the matching row
+            of X. The remaining columns store the estimated cumulated incidence (or 
+            probability) for each event.
         """
         if time_horizon is None:
             if self.time_horizon is None:

--- a/hazardous/_survival_boost.py
+++ b/hazardous/_survival_boost.py
@@ -284,15 +284,16 @@ class SurvivalBoost(BaseEstimator, ClassifierMixin):
         ----------
         X : array-like of shape (n_samples, n_features)
             The input samples.
-        time_horizon : int, float or array-like, default=None
+        time_horizon : int or float, default=None
             The time horizon at which to estimate the probabilities. If `None`, the
             `time_horizon` passed at the constructor is used. Therefore, this
             parameter allows to override the `time_horizon` set at the constructor.
 
         Returns
         -------
-        incidence_probabilities : ndarray of shape (n_events + 1, n_samples, n_times)
-            The incidence probabilities for each event at the given time horizon.
+        y_proba : ndarray of shape (n_events + 1, n_samples)
+            The first column holds the survival probability to any event and others the
+            incidence probabilities for each event.
         """
         if time_horizon is None:
             if self.time_horizon is None:
@@ -305,10 +306,14 @@ class SurvivalBoost(BaseEstimator, ClassifierMixin):
             else:
                 time_horizon = self.time_horizon
 
-        if isinstance(time_horizon, Real):
-            time_horizon = [time_horizon]
-        times = np.asarray(time_horizon)
-        return self.predict_cumulative_incidence(X, times=times)
+        if not isinstance(time_horizon, Real):
+            raise TypeError(
+                "The time_horizon parameter must be a real number. Use "
+                "predict_cumulative_incidence instead of predict_proba if you want "
+                "to predict at several time horizons."
+            )
+        times = np.asarray([time_horizon])
+        return self.predict_cumulative_incidence(X, times=times).squeeze()
 
     def predict_cumulative_incidence(self, X, times=None):
         r"""Estimate the cumulative incidence function for all events.

--- a/hazardous/_survival_boost.py
+++ b/hazardous/_survival_boost.py
@@ -292,8 +292,10 @@ class SurvivalBoost(BaseEstimator, ClassifierMixin):
         Returns
         -------
         y_proba : ndarray of shape (n_events + 1, n_samples)
-            The first column holds the survival probability to any event and others the
-            incidence probabilities for each event.
+            The estimated probabilities at the given time horizon. The first entry
+            at index 0 represents the survival probability (none of the events
+            occurring), whereas the remaining entries correspond to the incidence
+            probabilities for each specific event.
         """
         if time_horizon is None:
             if self.time_horizon is None:

--- a/hazardous/_survival_boost.py
+++ b/hazardous/_survival_boost.py
@@ -284,7 +284,7 @@ class SurvivalBoost(BaseEstimator, ClassifierMixin):
         ----------
         X : array-like of shape (n_samples, n_features)
             The input samples.
-        time_horizon : float or array-like, default=None
+        time_horizon : int, float or array-like, default=None
             The time horizon at which to estimate the probabilities. If `None`, the
             `time_horizon` passed at the constructor is used. Therefore, this
             parameter allows to override the `time_horizon` set at the constructor.

--- a/hazardous/_survival_boost.py
+++ b/hazardous/_survival_boost.py
@@ -297,7 +297,7 @@ class SurvivalBoost(BaseEstimator, ClassifierMixin):
             The estimated probabilities at the given time horizon. The column
             indexed 0 stores the estimated probabilities of staying event-free at the
             requested time horizon for each observation described the matching row
-            of X. The remaining columns store the estimated cumulated incidence (or 
+            of X. The remaining columns store the estimated cumulated incidence (or
             probability) for each event.
         """
         if time_horizon is None:
@@ -318,7 +318,9 @@ class SurvivalBoost(BaseEstimator, ClassifierMixin):
                 "to predict at several time horizons."
             )
         times = np.asarray([time_horizon])
-        return self.predict_cumulative_incidence(X, times=times).squeeze()
+        # TODO: it will be more natural for predict_cumulative_incidence to have a shape
+        # of (n_samples, n_events + 1, n_times) and thus avoid transposing here.
+        return self.predict_cumulative_incidence(X, times=times).squeeze().T
 
     def predict_cumulative_incidence(self, X, times=None):
         r"""Estimate the cumulative incidence function for all events.

--- a/hazardous/_survival_boost.py
+++ b/hazardous/_survival_boost.py
@@ -287,18 +287,16 @@ class SurvivalBoost(BaseEstimator, ClassifierMixin):
 
         time_horizon : int or float, default=None
             The time horizon at which to estimate the probabilities. If `None`, the
-            `time_horizon` passed at the constructor is used. Therefore, this
-            parameter allows to override the `time_horizon` parameter passed to
-            the constructor.
+            `time_horizon` passed at the constructor is used.
 
         Returns
         -------
         y_proba : ndarray of shape (n_samples, n_events + 1)
             The estimated probabilities at the given time horizon. The column
-            indexed 0 stores the estimated probabilities of staying event-free at the
-            requested time horizon for each observation described the matching row
-            of X. The remaining columns store the estimated cumulated incidence (or
-            probability) for each event.
+            indexed 0 stores the estimated probabilities of staying event-free at
+            the requested time horizon for each observation described by the matching
+            row of X. The remaining columns store the estimated cumulated incidence
+            (or probability) for each event.
         """
         if time_horizon is None:
             if self.time_horizon is None:

--- a/hazardous/_survival_boost.py
+++ b/hazardous/_survival_boost.py
@@ -280,17 +280,18 @@ class SurvivalBoost(BaseEstimator, ClassifierMixin):
     def predict_proba(self, X, time_horizon=None):
         """Estimate the probability of all incidences for a specific time horizon.
 
-        See the docstring for the `time_horizon` parameter for more details.
-
-        Returns a (n_events + 1)d array with shape (X.shape[0], n_events + 1).
-        The first column holds the survival probability to any event and others the
-        incicence probabilities for each event.
-
         Parameters
         ----------
         X : array-like of shape (n_samples, n_features)
             The input samples.
-        time_horizon : float or list, default=None
+        time_horizon : float or array-like, default=None
+            The time horizon at which to estimate the probabilities. If `None`, the
+            `time_horizon` passed at the constructor is used.
+
+        Returns
+        -------
+        incidence_probabilities : ndarray of shape (n_events + 1, n_samples, n_times)
+            The incidence probabilities for each event at the given time horizon.
         """
         if time_horizon is None:
             if self.time_horizon is None:

--- a/hazardous/tests/test_survival_boost.py
+++ b/hazardous/tests/test_survival_boost.py
@@ -70,6 +70,15 @@ def test_survival_boost_incidence_and_survival(seed):
 
 @pytest.mark.parametrize("seed", SEED_RANGE)
 def test_survival_boost_predict_proba(seed):
+    """Check the behaviour of the `predict_proba` method. Notably, we check:
+
+    - we raise an error when no `time_horizon` is set in the constructor nor
+      passed to `predict_proba`.
+    - we can pass `time_horizon` as a parameter to `predict_proba`.
+    - we can set `time_horizon` as a constructor parameter of `SurvivalBoost`.
+    - the `time_horizon` parameter passed to `predict_proba` is prioritized
+      over the constructor parameter.
+    """
     X, y = make_synthetic_competing_weibull(return_X_y=True, random_state=seed)
     assert sorted(y["event"].unique()) == [0, 1, 2, 3]
     n_events = 4
@@ -78,15 +87,12 @@ def test_survival_boost_predict_proba(seed):
     est = SurvivalBoost(n_iter=3, show_progressbar=False, random_state=seed)
     est.fit(X_train, y_train)
 
-    # Raise an error when `time_horizon` was not set in the constructor nor in
-    # passed to `predict_proba`.
     err_msg = (
         "The time_horizon parameter is required to use SurvivalBoost as a classifier."
     )
     with pytest.raises(ValueError, match=err_msg):
         est.predict_proba(X_test)
 
-    # Passing `time_horizon` as a parameter to `predict_proba`.
     time_horizon = 0
     y_pred = est.predict_proba(X_test, time_horizon=time_horizon)
     assert y_pred.shape == (n_events, X_test.shape[0], 1)
@@ -95,7 +101,6 @@ def test_survival_boost_predict_proba(seed):
     y_pred = est.predict_proba(X_test, time_horizon=time_horizon)
     assert y_pred.shape == (n_events, X_test.shape[0], len(time_horizon))
 
-    # Setting `time_horizon` as a constructor parameter of `SurvivalBoost`.
     time_horizon = 0
     est.set_params(time_horizon=time_horizon)
     y_pred = est.predict_proba(X_test)
@@ -106,8 +111,6 @@ def test_survival_boost_predict_proba(seed):
     y_pred = est.predict_proba(X_test)
     assert y_pred.shape == (n_events, X_test.shape[0], len(time_horizon))
 
-    # Check that passing `time_horizon` as a parameter to `predict_proba` is
-    # prioritized over the constructor parameter.
     time_horizon = [0, 10, 20]
     y_pred = est.predict_proba(X_test, time_horizon=time_horizon)
     assert y_pred.shape == (n_events, X_test.shape[0], len(time_horizon))

--- a/hazardous/tests/test_survival_boost.py
+++ b/hazardous/tests/test_survival_boost.py
@@ -93,31 +93,18 @@ def test_survival_boost_predict_proba(seed):
     with pytest.raises(ValueError, match=err_msg):
         est.predict_proba(X_test)
 
-    time_horizon = 0
-    y_pred = est.predict_proba(X_test, time_horizon=time_horizon)
-    assert y_pred.shape == (n_events, X_test.shape[0], 1)
-    assert_allclose(y_pred.sum(axis=0), 1.0)
-
-    time_horizon = [0, 10]
-    y_pred = est.predict_proba(X_test, time_horizon=time_horizon)
-    assert y_pred.shape == (n_events, X_test.shape[0], len(time_horizon))
-    assert_allclose(y_pred.sum(axis=0), 1.0)
+    err_msg = "The time_horizon parameter must be a real number."
+    with pytest.raises(TypeError, match=err_msg):
+        est.predict_proba(X_test, time_horizon=[0, 1])
 
     time_horizon = 0
-    est.set_params(time_horizon=time_horizon)
-    y_pred = est.predict_proba(X_test)
-    assert y_pred.shape == (n_events, X_test.shape[0], 1)
-    assert_allclose(y_pred.sum(axis=0), 1.0)
-
-    time_horizon = [0, 10]
-    est.set_params(time_horizon=time_horizon)
-    y_pred = est.predict_proba(X_test)
-    assert y_pred.shape == (n_events, X_test.shape[0], len(time_horizon))
-    assert_allclose(y_pred.sum(axis=0), 1.0)
-
-    time_horizon = [0, 10, 20]
     y_pred = est.predict_proba(X_test, time_horizon=time_horizon)
-    assert y_pred.shape == (n_events, X_test.shape[0], len(time_horizon))
+    assert y_pred.shape == (n_events, X_test.shape[0])
+    assert_allclose(y_pred.sum(axis=0), 1.0)
+
+    est.set_params(time_horizon=time_horizon)
+    y_pred = est.predict_proba(X_test)
+    assert y_pred.shape == (n_events, X_test.shape[0])
     assert_allclose(y_pred.sum(axis=0), 1.0)
 
 

--- a/hazardous/tests/test_survival_boost.py
+++ b/hazardous/tests/test_survival_boost.py
@@ -66,7 +66,51 @@ def test_survival_boost_incidence_and_survival(seed):
         cif_pred[1:, :, 0].sum(axis=0),
         cif_pred[1:, :, -1].sum(axis=0),
     )
-    # TODO: add assertion about the .score method
+
+
+@pytest.mark.parametrize("seed", SEED_RANGE)
+def test_survival_boost_predict_proba(seed):
+    X, y = make_synthetic_competing_weibull(return_X_y=True, random_state=seed)
+    assert sorted(y["event"].unique()) == [0, 1, 2, 3]
+    n_events = 4
+
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=seed)
+    est = SurvivalBoost(n_iter=3, show_progressbar=False, random_state=seed)
+    est.fit(X_train, y_train)
+
+    # Raise an error when `time_horizon` was not set in the constructor nor in
+    # passed to `predict_proba`.
+    err_msg = (
+        "The time_horizon parameter is required to use SurvivalBoost as a classifier."
+    )
+    with pytest.raises(ValueError, match=err_msg):
+        est.predict_proba(X_test)
+
+    # Passing `time_horizon` as a parameter to `predict_proba`.
+    time_horizon = 0
+    y_pred = est.predict_proba(X_test, time_horizon=time_horizon)
+    assert y_pred.shape == (n_events, X_test.shape[0], 1)
+
+    time_horizon = [0, 10]
+    y_pred = est.predict_proba(X_test, time_horizon=time_horizon)
+    assert y_pred.shape == (n_events, X_test.shape[0], len(time_horizon))
+
+    # Setting `time_horizon` as a constructor parameter of `SurvivalBoost`.
+    time_horizon = 0
+    est.set_params(time_horizon=time_horizon)
+    y_pred = est.predict_proba(X_test)
+    assert y_pred.shape == (n_events, X_test.shape[0], 1)
+
+    time_horizon = [0, 10]
+    est.set_params(time_horizon=time_horizon)
+    y_pred = est.predict_proba(X_test)
+    assert y_pred.shape == (n_events, X_test.shape[0], len(time_horizon))
+
+    # Check that passing `time_horizon` as a parameter to `predict_proba` is
+    # prioritized over the constructor parameter.
+    time_horizon = [0, 10, 20]
+    y_pred = est.predict_proba(X_test, time_horizon=time_horizon)
+    assert y_pred.shape == (n_events, X_test.shape[0], len(time_horizon))
 
 
 @pytest.mark.parametrize("seed", SEED_RANGE)

--- a/hazardous/tests/test_survival_boost.py
+++ b/hazardous/tests/test_survival_boost.py
@@ -98,8 +98,8 @@ def test_survival_boost_predict_proba(seed):
 
     time_horizon = 0
     y_pred = est.predict_proba(X_test, time_horizon=time_horizon)
-    assert y_pred.shape == (n_events, X_test.shape[0])
-    assert_allclose(y_pred.sum(axis=0), 1.0)
+    assert y_pred.shape == (X_test.shape[0], n_events)
+    assert_allclose(y_pred.sum(axis=1), 1.0)
 
     est.set_params(time_horizon=time_horizon)
     y_pred = est.predict_proba(X_test)

--- a/hazardous/tests/test_survival_boost.py
+++ b/hazardous/tests/test_survival_boost.py
@@ -74,10 +74,9 @@ def test_survival_boost_predict_proba(seed):
 
     - we raise an error when no `time_horizon` is set in the constructor nor
       passed to `predict_proba`.
+    - we raise an error when `time_horizon` is not a real number.
     - we can pass `time_horizon` as a parameter to `predict_proba`.
     - we can set `time_horizon` as a constructor parameter of `SurvivalBoost`.
-    - the `time_horizon` parameter passed to `predict_proba` is prioritized
-      over the constructor parameter.
     """
     X, y = make_synthetic_competing_weibull(return_X_y=True, random_state=seed)
     assert sorted(y["event"].unique()) == [0, 1, 2, 3]

--- a/hazardous/tests/test_survival_boost.py
+++ b/hazardous/tests/test_survival_boost.py
@@ -96,24 +96,29 @@ def test_survival_boost_predict_proba(seed):
     time_horizon = 0
     y_pred = est.predict_proba(X_test, time_horizon=time_horizon)
     assert y_pred.shape == (n_events, X_test.shape[0], 1)
+    assert_allclose(y_pred.sum(axis=0), 1.0)
 
     time_horizon = [0, 10]
     y_pred = est.predict_proba(X_test, time_horizon=time_horizon)
     assert y_pred.shape == (n_events, X_test.shape[0], len(time_horizon))
+    assert_allclose(y_pred.sum(axis=0), 1.0)
 
     time_horizon = 0
     est.set_params(time_horizon=time_horizon)
     y_pred = est.predict_proba(X_test)
     assert y_pred.shape == (n_events, X_test.shape[0], 1)
+    assert_allclose(y_pred.sum(axis=0), 1.0)
 
     time_horizon = [0, 10]
     est.set_params(time_horizon=time_horizon)
     y_pred = est.predict_proba(X_test)
     assert y_pred.shape == (n_events, X_test.shape[0], len(time_horizon))
+    assert_allclose(y_pred.sum(axis=0), 1.0)
 
     time_horizon = [0, 10, 20]
     y_pred = est.predict_proba(X_test, time_horizon=time_horizon)
     assert y_pred.shape == (n_events, X_test.shape[0], len(time_horizon))
+    assert_allclose(y_pred.sum(axis=0), 1.0)
 
 
 @pytest.mark.parametrize("seed", SEED_RANGE)

--- a/hazardous/tests/test_survival_boost.py
+++ b/hazardous/tests/test_survival_boost.py
@@ -103,8 +103,8 @@ def test_survival_boost_predict_proba(seed):
 
     est.set_params(time_horizon=time_horizon)
     y_pred = est.predict_proba(X_test)
-    assert y_pred.shape == (n_events, X_test.shape[0])
-    assert_allclose(y_pred.sum(axis=0), 1.0)
+    assert y_pred.shape == (X_test.shape[0], n_events)
+    assert_allclose(y_pred.sum(axis=1), 1.0)
 
 
 @pytest.mark.parametrize("seed", SEED_RANGE)

--- a/hazardous/tests/test_survival_boost.py
+++ b/hazardous/tests/test_survival_boost.py
@@ -77,6 +77,8 @@ def test_survival_boost_predict_proba(seed):
     - we raise an error when `time_horizon` is not a real number.
     - we can pass `time_horizon` as a parameter to `predict_proba`.
     - we can set `time_horizon` as a constructor parameter of `SurvivalBoost`.
+    - check that passing `time_horizon` to `predict_proba` overrides the
+      constructor parameter.
     """
     X, y = make_synthetic_competing_weibull(return_X_y=True, random_state=seed)
     assert sorted(y["event"].unique()) == [0, 1, 2, 3]
@@ -105,6 +107,19 @@ def test_survival_boost_predict_proba(seed):
     y_pred = est.predict_proba(X_test)
     assert y_pred.shape == (X_test.shape[0], n_events)
     assert_allclose(y_pred.sum(axis=1), 1.0)
+
+    time_horizon_0, time_horizon_1_000 = 0, 1_000
+    y_pred_overridden = (
+        est.set_params(time_horizon=time_horizon_0)
+        .fit(X_train, y_train)
+        .predict_proba(X_test, time_horizon=time_horizon_1_000)
+    )
+    y_pred_default = (
+        est.set_params(time_horizon=time_horizon_1_000)
+        .fit(X_train, y_train)
+        .predict_proba(X_test)
+    )
+    assert_allclose(y_pred_overridden, y_pred_default)
 
 
 @pytest.mark.parametrize("seed", SEED_RANGE)


### PR DESCRIPTION
There is a bug in `SurvivalBoost.predict_proba`. The `time_horizon` parameter does not currently accept array-like while it should.