### PR TITLE
MAINT activate doctest check with pytest by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,3 +118,8 @@ target-version = "py39"
 
 [tool.ruff.mccabe]
 max-complexity = 10
+
+
+[tool.pytest.ini_options]
+addopts = "--doctest-modules"
+doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"


### PR DESCRIPTION
Since we start to have some docstring, we could activate `doctest` check when testing with `pytest`.