### PR TITLE
FIX do not pytest collect outside of the hazardous module folder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,3 +123,6 @@ max-complexity = 10
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
+testpaths = [
+    "hazardous",
+]


### PR DESCRIPTION
I noticed that pytest was very slow because it was silently running the examples at collection time.