### PR TITLE
CI trigger build doc on all targeted branches

### DIFF
--- a/.github/workflows/push_doc.yml
+++ b/.github/workflows/push_doc.yml
@@ -7,7 +7,7 @@ on:
       - test-ci*
   pull_request:
     branches:
-      - main
+      - '**'
 
 permissions:
   contents: write


### PR DESCRIPTION
This should allow to trigger the documentation build and preview even when targeting another branch than "main".