### PR TITLE
add censor set and KM time sampler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,5 +164,9 @@ cython_debug/
 doc/generated/
 
 
+# Remove files auto-generated from mac
+*.DS_Store
+
 # This dataset should not be redistributed, because users have to sign an agreement.
 hazardous/data/seer_cancer_cardio_raw_data.txt
+hazardous/data/*.txt

--- a/hazardous/_ipcw.py
+++ b/hazardous/_ipcw.py
@@ -3,9 +3,132 @@ from lifelines import KaplanMeierFitter
 from scipy.interpolate import interp1d
 from sklearn.base import clone
 from sklearn.ensemble import HistGradientBoostingClassifier
+from sklearn.preprocessing import MinMaxScaler
 from sklearn.utils.validation import check_is_fitted
 
 from .utils import check_y_survival
+
+
+class KaplanMeierEstimator:
+    """Estimate the Inverse Probability of Censoring Weight (IPCW).
+
+    This class estimates the inverse probability of 'survival' to censoring using the
+    Kaplan-Meier estimator applied to a binary indicator for censoring, defined as the
+    negation of the binary indicator for any event occurrence. This estimator assumes
+    that the censoring distribution is independent of the covariates X. If this
+    assumption is violated, the estimator may be biased, and a conditional estimator
+    might be more appropriate.
+
+    This approach is useful for correcting the bias introduced by right censoring in
+    survival analysis, particularly when computing model evaluation metrics such as
+    the Brier score or the concordance index.
+
+    Note that the term 'IPCW' can be somewhat misleading: IPCW values represent the
+    inverse of the probability of remaining censor-free (or uncensored) at a given time.
+    For instance, at t=0, the probability of being censored is 0, so the probability of
+    being uncensored is 1.0, and its inverse is also 1.0.
+
+    By construction, IPCW values are always greater than or equal to 1.0 and can only
+    increase over time. If no observations are censored, the IPCW values remain
+    uniformly at 1.0.
+
+    Note: This estimator extrapolates by maintaining a constant value equal to the last
+    observed IPCW value beyond the last recorded time point.
+
+    Parameters
+    ----------
+    epsilon_censoring_prob : float, default=0.05
+        Lower limit of the predicted censoring probabilities. It helps avoiding
+        instabilities during the division to obtain IPCW.
+
+    Attributes
+    ----------
+    min_censoring_prob_ : float
+        The effective minimal probability used, defined as the max between
+        min_censoring_prob and the minimum predicted probability.
+
+    unique_times_ : ndarray of shape (n_unique_times,)
+        The observed censoring durations from the training target.
+
+    censoring_survival_probs_ : ndarray of shape (n_unique_times,)
+        The estimated censoring survival probabilities.
+
+    censoring_survival_func_ : callable
+        The linear interpolation function defined with unique_times_ (x) and
+        censoring_survival_probs_ (y).
+    """
+
+    def __init__(self):
+        pass
+
+    def fit(self, y, X=None):
+        """Marginal estimation of the censoring survival function
+
+        In addition to running the Kaplan-Meier estimator on the negated event
+        labels (1 for censoring, 0 for any event), this methods also fits
+        interpolation function to be able to make prediction at any time.
+
+        Parameters
+        ----------
+        y : array-like of shape (n_samples, 2)
+            The target data.
+
+        X : None
+            The input samples. Unused since this estimator is non-conditional.
+
+        Returns
+        -------
+        self : object
+            Fitted estimator.
+        """
+        event, duration = check_y_survival(y)
+
+        km = KaplanMeierFitter()
+        km.fit(
+            durations=duration,
+            event_observed=event,
+        )
+
+        df = km.survival_function_
+        self.unique_times_ = df.index
+        self.survival_probs_ = df.values[:, 0]
+        scaler = MinMaxScaler()
+        self.survival_probs_rescaled = scaler.fit_transform(
+            self.survival_probs_.reshape(-1, 1)
+        ).flatten()
+
+        self.survival_func_ = interp1d(
+            self.unique_times_,
+            self.survival_probs_,
+            kind="previous",
+            bounds_error=False,
+            fill_value="extrapolate",
+        )
+
+        self.inverse_surv_func_rescaled = interp1d(
+            1 - self.survival_probs_rescaled,
+            self.unique_times_,
+            kind="previous",
+            bounds_error=False,
+            fill_value="extrapolate",
+        )
+        self.survival_func_rescaled = interp1d(
+            self.unique_times_,
+            self.survival_probs_rescaled,
+            kind="previous",
+            bounds_error=False,
+            fill_value="extrapolate",
+        )
+
+        self.inverse_surv_func_ = interp1d(
+            1 - self.survival_probs_,
+            self.unique_times_,
+            kind="previous",
+            bounds_error=False,
+            fill_value="extrapolate",
+        )
+
+        return self
 
 
 class KaplanMeierIPCW:
@@ -104,6 +227,14 @@ class KaplanMeierIPCW:
         self.censoring_survival_func_ = interp1d(
             self.unique_times_,
             self.censoring_survival_probs_,
+            kind="previous",
+            bounds_error=False,
+            fill_value="extrapolate",
+        )
+
+        self.inverse_surv_func_ = interp1d(
+            1 - self.censoring_survival_probs_,
+            self.unique_times_,
             kind="previous",
             bounds_error=False,
             fill_value="extrapolate",

--- a/hazardous/metrics/_brier_score.py
+++ b/hazardous/metrics/_brier_score.py
@@ -38,6 +38,7 @@ class IncidenceScoreComputer:
         y_train,
         event_of_interest="any",
         ipcw_estimator=None,
+        y_censor=None,
     ):
         self.y_train = y_train
         self.event_train, self.duration_train = check_y_survival(y_train)
@@ -45,14 +46,25 @@ class IncidenceScoreComputer:
         self.any_event_train = self.event_train > 0
         self.event_of_interest = event_of_interest
 
-        y = dict(
-            event=self.any_event_train,
-            duration=self.duration_train,
+        if y_censor is not None:
+            self.event_censor, self.duration_censor = check_y_survival(y_censor)
+            self.y_censor = y_censor
+            self.any_event_censor = self.event_censor > 0
+
+        else:
+            self.event_censor = self.event_train
+            self.duration_censor = self.duration_train
+            self.y_censor = y_train
+            self.any_event_censor = self.any_event_train
+
+        y_ = dict(
+            event=self.any_event_censor,
+            duration=self.duration_censor,
         )
-        # Estimate the censoring distribution from the training set.
+        # Estimate the censoring distribution from the censor set.
         if ipcw_estimator is None:
             ipcw_estimator = KaplanMeierIPCW()
-        self.ipcw_estimator = ipcw_estimator.fit(y)
+        self.ipcw_estimator = ipcw_estimator.fit(y_)
 
     def brier_score_survival(self, y_true, y_pred, times):
         """Time-dependent Brier score of a survival function estimate.

--- a/hazardous/utils.py
+++ b/hazardous/utils.py
@@ -53,3 +53,17 @@ def check_event_of_interest(k):
             f"got: event_of_interest={k}"
         )
     return
+
+
+def make_time_grid(duration, n_steps=20):
+    t_min, t_max = duration.min(), duration.max()
+    return np.linspace(t_min, t_max, n_steps)
+
+
+def make_recarray(y):
+    event = y["event"].values
+    duration = y["duration"].values
+    return np.array(
+        [(event[i], duration[i]) for i in range(y.shape[0])],
+        dtype=[("e", bool), ("t", float)],
+    )


### PR DESCRIPTION
different things added: 
- add a censor set to separate the training of the CIFS from the censoring distribution 
- add an argument: time_sampler. 
   - time_sampler='uniform' -> stay as it was. We sample a time uniformly between (0, t_max)
   - time_sampler='kaplan_meier' -> we train a Kaplan Meier estimator to learn the survival distribution and sample time to have more sampled time where the events of interest actually happen. 

TODO before PR: 
- Adding documentation 
- Adding tests