### PR TITLE
docs: Hide redundant table of contents in the index page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -79,6 +79,7 @@ Proper Scoring Rule and Stochastic Optimization with Competing Risks
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
+   :hidden:
 
    api
    auto_examples/index


### PR DESCRIPTION
Currently, in the index page of the online docs, there is this:

![Capture d’écran 2025-03-08 à 11 52 40](https://github.com/user-attachments/assets/edfe76fa-e7db-4f42-9cdf-58eca14110c3)

At the end of the screenshot, the table of contents is redundant with the top navigation bar.

This small PR hides this table of contents (for screen real estate purposes).