### PR TITLE
adding new python versions to hazardous

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,10 @@ jobs:
             nox-session: test_latest_from_pypi
           - python-version: "3.12"
             nox-session: test_latest_from_pypi
+          - python-version: "3.13"
+            nox-session: test_latest_from_pypi
+          - python-version: "3.14"
+            nox-session: test_latest_from_pypi
 
       fail-fast: false
 
@@ -64,7 +68,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.12"
+          - python-version: "3.14"
             nox-session: test_latest_from_conda_forge
 
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           allow-prereleases: true
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,7 +19,7 @@ def test_latest_from_pypi(session):
 @nox.session(python=["3.14"], venv_backend="mamba")
 def test_latest_from_conda_forge(session):
     # Test the newest versions of the dependencies from conda-forge.
-    # XXX: hown to do the same with a single mamba install command?
+    # XXX: how to do the same with a single mamba install command?
     for package_name in [
         "pytest",
         "pytest-cov",

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,14 +9,14 @@ def _common_test_steps(session):
         session.run("pytest", "-v", "--cov", "--pyargs", "hazardous")
 
 
-@nox.session(python=["3.10", "3.11", "3.12"])
+@nox.session(python=["3.10", "3.11", "3.12", "3.13", "3.14"])
 def test_latest_from_pypi(session):
     # Test the newest versions of the dependencies.
     session.install(".[test]")
     _common_test_steps(session)
 
 
-@nox.session(python=["3.12"], venv_backend="mamba")
+@nox.session(python=["3.14"], venv_backend="mamba")
 def test_latest_from_conda_forge(session):
     # Test the newest versions of the dependencies from conda-forge.
     # XXX: hown to do the same with a single mamba install command?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,11 @@ readme = "README.md"
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
@@ -122,7 +127,7 @@ line-length = 88
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.mccabe]
 max-complexity = 10


### PR DESCRIPTION
Currently, we support only python 3.10, 3.11, 3.12
and we will also support 3.13, 3.14